### PR TITLE
[#68] Added xargs to remove space from values

### DIFF
--- a/tyaml/tyaml
+++ b/tyaml/tyaml
@@ -47,7 +47,7 @@ get_value()
 {
    local file=$1
    local path=$2
-   list_all_paths $file | get_matched_path $path | remove_parent_path $path
+   list_all_paths $file | get_matched_path $path | remove_parent_path $path | xargs
 }
 
 list_keys()


### PR DESCRIPTION
Added `xargs` to remove space from values

Exemple file:

```yaml
default.engine:google
default.program:firefox
engine.google.query:menes
engine.youtube.query: https://www.youtube.com/results?search_query=TERM
engine.duckduckgo.query: https://www.duckduckgo.com/?q=TERM
engine.netflix.query: https://www.netflix.com/search?q=TERM
engine.stack_overflow.query: https://stackoverflow.com/search?q=TERM
engine.google_maps.query: https://www.google.com/maps/search/TERM
engine.translate.query: https://translate.google.com/?sl=auto&tl=$LANG&text=TERM
engine.reddit.query: https://www.reddit.com/search/?q=TERM
program.firefox.command:firefox
program.qutebrowser.command:qutebrowser
program.chrome.command:google-chrome-stable
```

The items with a space after `:` will now be displayed without space(trimmed).

* Command to test:

`tyaml params.yml -v engine.youtube.query`

* The output will be:

`https://www.youtube.com/results?search_query=TERM`