### PR TITLE
Ported tgoeswall from python to bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,11 @@ tnotes: ${CONFIG_FOLDER} ${BIN_FOLDER}
 tgoeswall: ${CONFIG_FOLDER} ${BIN_FOLDER}
 	@echo "Installing tgoeswall..."
 	install -m 555 tgoeswall/tgoeswall ${BIN_FOLDER}
+	install -m 555 tgoeswall/tgoeswallctrl ${BIN_FOLDER}
+	install tgoeswall/tgoeswall.conf ${CONFIG_FOLDER}
+	install tgoeswall/tgoeswall.service /etc/systemd/user/
+	install tgoeswall/tgoeswall.timer /etc/systemd/user/
+	sudo -u ${SUDO_USER} systemctl --user enable tgoeswall.timer
 	@echo "done!"
 
 tprogbar: ${BIN_FOLDER}

--- a/Makefile
+++ b/Makefile
@@ -47,16 +47,6 @@ tnotes: ${CONFIG_FOLDER} ${BIN_FOLDER}
 	install -m 555 tnotes/dmenu_tnotes ${BIN_FOLDER}
 	@echo "done!"
 
-tgoeswall: ${CONFIG_FOLDER} ${BIN_FOLDER}
-	@echo "Installing tgoeswall..."
-	install -m 555 tgoeswall/tgoeswall ${BIN_FOLDER}
-	install -m 555 tgoeswall/tgoeswallctrl ${BIN_FOLDER}
-	install tgoeswall/tgoeswall.conf ${CONFIG_FOLDER}
-	install tgoeswall/tgoeswall.service /etc/systemd/user/
-	install tgoeswall/tgoeswall.timer /etc/systemd/user/
-	sudo -u ${SUDO_USER} systemctl --user enable tgoeswall.timer
-	@echo "done!"
-
 tprogbar: ${BIN_FOLDER}
 	@echo "Installing tprogbar..."
 	install -m 555 tprogbar/tprogbar ${BIN_FOLDER}
@@ -70,17 +60,18 @@ uninstall:
 	rm -fr /usr/share/sounds/tpomodoro/
 	rm -f ${BIN_FOLDER}/ttodo
 	rm -f ${BIN_FOLDER}/dmenu_ttodo
-	make -C tmenu/ uninstall
+	${MAKE} -C tmenu/ uninstall
 	rm -f ${BIN_FOLDER}/tyaml
 	rm -f ${BIN_FOLDER}/tnotes
 	rm -f ${BIN_FOLDER}/dmenu_tnotes
-	rm -f ${BIN_FOLDER}/tgoeswall
 	rm -fr ${CONFIG_FOLDER}
 	rm -f ${BIN_FOLDER}/tprogbar
+	${MAKE} -C tgoeswall/ uninstall
 	@echo "done!"
 
-install: tsearch ttodo tyaml tnotes tgoeswall tpomodoro tprogbar
-	make -C tmenu/ install
+install: tsearch ttodo tyaml tnotes tpomodoro tprogbar
+	${MAKE} -C tmenu/ install
+	${MAKE} -C tgoeswall/ install
 	@echo "tinytools installed successfully!"
 
-.PHONY: install tsearch tpomodoro ttodo tyaml tnotes tgoeswall uninstall tprogbar
+.PHONY: install tsearch tpomodoro ttodo tyaml tnotes uninstall tprogbar

--- a/tgoeswall/Makefile
+++ b/tgoeswall/Makefile
@@ -12,7 +12,6 @@ install:
 	install -D gtgoeswall.conf /etc/tinytools
 	install tgoeswall.service /etc/systemd/user/
 	install tgoeswall.timer /etc/systemd/user/
-	sudo -u ${SUDO_USER} systemctl --user enable tgoeswall.timer
 	@echo "done!"
 
 clean:
@@ -22,8 +21,7 @@ distclean: clean
 
 uninstall:
 	@echo "Uninstall tgoeswall"
-	sudo -u ${SUDO_USER} systemctl --user stop tgoeswall
-	sudo -u ${SUDO_USER} systemctl --user disable tgoeswall
+	systemctl --disable disable tgoeswall
 	rm -f $(DESTDIR)$(prefix)bin/tgoeswall
 	rm -f $(DESTDIR)$(prefix)bin/tgoeswallctrl
 	rm -f /etc/systemd/user/tgoeswall.service

--- a/tgoeswall/Makefile
+++ b/tgoeswall/Makefile
@@ -1,0 +1,33 @@
+.POSIX:
+
+prefix = /usr/local
+
+all:
+	@echo "all target"
+
+install:
+	@echo "Installing tgoeswall..."
+	install -m 555 tgoeswall $(DESTDIR)$(prefix)/bin/tgoeswall
+	install -m 555 tgoeswallctrl $(DESTDIR)$(prefix)/bin/tgoeswallctrl
+	install -D gtgoeswall.conf /etc/tinytools
+	install tgoeswall.service /etc/systemd/user/
+	install tgoeswall.timer /etc/systemd/user/
+	sudo -u ${SUDO_USER} systemctl --user enable tgoeswall.timer
+	@echo "done!"
+
+clean:
+	@echo "Cleaning tgoeswall"
+
+distclean: clean
+
+uninstall:
+	@echo "Uninstall tgoeswall"
+	sudo -u ${SUDO_USER} systemctl --user stop tgoeswall
+	sudo -u ${SUDO_USER} systemctl --user disable tgoeswall
+	rm -f $(DESTDIR)$(prefix)bin/tgoeswall
+	rm -f $(DESTDIR)$(prefix)bin/tgoeswallctrl
+	rm -f /etc/systemd/user/tgoeswall.service
+	rm -f /etc/systemd/user/tgoeswall.timer
+	@echo "done!"
+
+.PHONY: all install clean distclean uninstall

--- a/tgoeswall/Makefile
+++ b/tgoeswall/Makefile
@@ -21,7 +21,7 @@ distclean: clean
 
 uninstall:
 	@echo "Uninstall tgoeswall"
-	systemctl --disable disable tgoeswall
+	systemctl --user disable tgoeswall
 	rm -f $(DESTDIR)$(prefix)bin/tgoeswall
 	rm -f $(DESTDIR)$(prefix)bin/tgoeswallctrl
 	rm -f /etc/systemd/user/tgoeswall.service

--- a/tgoeswall/Makefile
+++ b/tgoeswall/Makefile
@@ -9,9 +9,10 @@ install:
 	@echo "Installing tgoeswall..."
 	install -m 555 tgoeswall $(DESTDIR)$(prefix)/bin/tgoeswall
 	install -m 555 tgoeswallctrl $(DESTDIR)$(prefix)/bin/tgoeswallctrl
-	install -D gtgoeswall.conf /etc/tinytools
+	install -D tgoeswall.conf /etc/tinytools
 	install tgoeswall.service /etc/systemd/user/
 	install tgoeswall.timer /etc/systemd/user/
+	systemctl --global daemon-reload
 	@echo "done!"
 
 clean:

--- a/tgoeswall/Makefile
+++ b/tgoeswall/Makefile
@@ -12,7 +12,6 @@ install:
 	install -D tgoeswall.conf /etc/tinytools
 	install tgoeswall.service /etc/systemd/user/
 	install tgoeswall.timer /etc/systemd/user/
-	systemctl --global daemon-reload
 	@echo "done!"
 
 clean:

--- a/tgoeswall/README.md
+++ b/tgoeswall/README.md
@@ -8,6 +8,8 @@ The Geostationary Operational Environmental Satellite system (GOES), operated by
 
 This script downloads one image every 10 minutes from GOES server, and applyes it as your wallpaper.
 
+To install this script, avoid doing it with `root`. Install it using `sudo`.
+
 ## Dependencies
 
 * wget

--- a/tgoeswall/README.md
+++ b/tgoeswall/README.md
@@ -2,43 +2,57 @@
 
 I'm using [GOES](https://www.star.nesdis.noaa.gov/GOES/) images to be my wallpaper, such as macOS Mojave's dynamic wallpaper.
 
-![](.screenshots/2019-05-18_23-12.png)
+![](https://cdn.star.nesdis.noaa.gov/GOES16/ABI/FD/GEOCOLOR/thumbnail.jpg)
 
 The Geostationary Operational Environmental Satellite system (GOES), operated by the United States' National Oceanic and Atmospheric Administration (NOAA)'s National Environmental Satellite, Data, and Information Service division, supports weather forecasting, severe storm tracking, and meteorology research[[1]](https://en.wikipedia.org/wiki/Geostationary_Operational_Environmental_Satellite).
 
+This script downloads one image every 10 minutes from GOES server, and applyes it as your wallpaper.
+
 ## Dependencies
 
-* Python 3.x
+* wget
 * feh
 
 ## Usage
 
-To run with default configuration (resolution of 339 pixels) run:
+After installation you can change some configurations by editing a file placed in `/etc/tinytools/tgoeswall.conf`.
 
-```
-$ python3 goes_dynamic_wallpaper
-```
+The options available are:
 
-You can also inform the resolution and the path you want to store the images.
+* `path`: path that the `tgoeswall` service will use to download the GOES image(preferably `/tmp/`).
+* `resolution`: resolution of the image to be downloaded, it can be `678`, `1808`, `5424` or `10848`.
+* `feh_args`: args that will be used by `feh`. Check `feh` manpage to see the options available.
 
-``` 
-$ python3 goes_dynamic_wallpaper -r 1808 -p path_where_to_store_images
+The default options can be seen as follows:
+
+```yaml
+path:/tmp/tgoeswall/
+resolution: 1808
+feh_args: --bg-max
 ```
 
 This script doesn't persist images for too long because they can be huge files(greater than 72MB sometimes).
 
-# Team
+You can `start|stop` the service with `systemctl`: 
 
-| <img src="https://github.com/Calebe94.png?size=200" alt="Edimar Calebe Castanho"> | 
-|:---------------------------------------------------------------------------------:|
-| [Edimar Calebe Castanho (Calebe94)](https://github.com/Calebe94)                  |
+```bash
+$ systemctl --user start tgoeswall
+$ systemctl --user stop tgoeswall
+```
 
-# License
+Also you can check the script log with `journalctl`:
 
-All software is covered under [MIT License](https://opensource.org/licenses/MIT).
+```bash
+$ journalctl --user -fu tgoeswall
+```
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+## Team
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+| <img src="https://github.com/Calebe94.png?size=200" alt="Edimar Calebe Castanho"> | <img src="https://github.com/gbgabo.png?size=200" alt="Gabriel Gaboardi"> | 
+|:---------------------------------------------------------------------------------:|:-------------------------------------------------------------------------:|
+| [Edimar Calebe Castanho (Calebe94)](https://github.com/Calebe94)                  | [Gabriel Gaboardi (Gabo)](https://github.com/gbgabo)                      |
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+## License
+
+All software is covered under [GNU General Public License v3.0](https://www.gnu.org/licenses/gpl-3.0.en.html).
+

--- a/tgoeswall/README.md
+++ b/tgoeswall/README.md
@@ -15,9 +15,25 @@ To install this script, avoid doing it with `root`. Install it using `sudo`.
 * wget
 * feh
 
+## Instalation
+
+To install `tgoeswall` you can edit the `Makefile` to match your local setup (`tgoeswall` is installed into the `/usr/local/bin` by default).
+
+Afterwards enter the following command to install `tgoeswall` (if necessary as root).
+
+```bash
+sudo make install
+```
+
+After the installation you can enable `tgoeswall` to run as a service by running the following command (as user not as root):
+
+```bash
+tgoeswallctrl start
+```
+
 ## Usage
 
-After installation you can change some configurations by editing a file placed in `/etc/tinytools/tgoeswall.conf`.
+After installation you can change some configurations of `tgoeswall` service by editing a file placed in `/etc/tinytools/tgoeswall.conf`.
 
 The options available are:
 
@@ -46,6 +62,18 @@ Also you can check the script log with `journalctl`:
 
 ```bash
 $ journalctl --user -fu tgoeswall
+```
+
+You can use tgoeswall to download GOES images into your current folder by running the following command:
+
+```bash
+tgoeswall -r 1808
+```
+
+Where `-r` is the image resolution. You can always check the available commands by running:
+
+```bash
+tgoeswall -h
 ```
 
 ## Team

--- a/tgoeswall/tgoeswall
+++ b/tgoeswall/tgoeswall
@@ -1,131 +1,80 @@
-#!/usr/bin/python3
-"""
-    GOES GEOCOLOR - https://www.star.nesdis.noaa.gov/GOES/
-    GOES-East - Latest Full Disk Images
-    Images updated every 10 minutes.
-"""
+#!/bin/bash
 
-import datetime, subprocess, time, os, urllib.request, argparse, logging
+#This file is part of the TinyTools distribution (https://github.com/Calebe94/TinyTools).
+#Copyright (C)  TinyTools
 
-CDN_URL = "https://cdn.star.nesdis.noaa.gov/GOES16/ABI/FD/GEOCOLOR/{}_GOES16-ABI-FD-GEOCOLOR-{}.jpg"
+#This program is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, version 3 of the License.
 
-IMAGES_RESOLUTIONS = [
-        "339",
-        "678",
-        "1808",
-        "5424",
-        "10848"
-    ]
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
 
-TIME_FORMAT = "%Y%j%H%M"
-WALLPAPERS_FOLDER = "wallpaper"
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-DEFAULT_FOLDER = os.path.abspath(os.path.join(os.path.abspath(__file__), "../", "wallpaper"))
+GOES_CDN="https://cdn.star.nesdis.noaa.gov/GOES16/ABI/FD/GEOCOLOR/"
+WGET_CMD="wget -N -q --show-progress"
 
-class Wallpaper(object):
-    __folder = str()
-    __resolution = str()
-    __utc_time = str()
-    
-    def __init__(self, folder=DEFAULT_FOLDER, resolution=339):
-        self.__folder = folder
-        self.__resolution = "{0}x{0}".format(resolution)
-        if not os.path.isdir(self.__folder):
-            os.mkdir(self.__folder)
-        logging.debug("Program initialized in {} folder.".format(self.__folder))
+usage()
+{
+    echo "usage: tgoeswall [-r <resolution>] [-t] [-l]"
+    echo "options:"
+    echo "-r: download image by a given resolution(avaliable: 678, 1808, 5424, 10848);"
+    echo "-t: download thumbnail image(the smallest image);"
+    echo "-l: download latest image(the biggest image)."
+}
 
-    def delete_last_wallpaper(self, actual_wallpaper):
-        file_lists = os.listdir(self.__folder)
-        logging.debug("Deleting {} files.".format(file_lists))
-        for file in file_lists:
-            if file != actual_wallpaper:
-                os.remove(os.path.join(self.__folder , file))
 
-    def apply_wallpaper(self, filename):
-        logging.debug("Applying {} image as wallpaper.".format(filename))
-        commands = [
-            "feh",
-            "--bg-center",
-            os.path.join(self.__folder, filename)
-        ]
-        subprocess.Popen(commands).wait()
+download_latest()
+{
+    $WGET_CMD $GOES_CDN/latest.jpg
+}
 
-    def apply_last_wallpaper(self):
-        logging.debug("Trying to apply the last image")
-        try:
-            file_lists = os.listdir(self.__folder)
-            file_lists.sort()
-            self.apply_wallpaper(file_lists[-1])
-        except Exception as error:
-            logging.debug(error)
+download_thumb()
+{
+    $WGET_CMD $GOES_CDN/thumbnail.jpg
+}
 
-    def download_image(self, utc_time, resolution):
-        image_url = CDN_URL.format(utc_time, resolution)
-        filename = image_url.split('/')[-1]
-        logging.debug("Downloading {} image.".format(filename))
-        urllib.request.urlretrieve(image_url, self.__folder+"/"+filename)
-        return filename
+download_image()
+{
+    res="$1"
+    $WGET_CMD $GOES_CDN/$res"x"$res".jpg"
+}
 
-    def update_wallpaper(self):
-        last_image = (datetime.datetime.utcnow() - datetime.timedelta(seconds=60*30)).strftime(TIME_FORMAT)
-        last_image = last_image[:-1]+"0"
-        logging.debug("Last UTC image is {}.".format(last_image))
-        try:
-            filename = self.download_image(last_image, self.__resolution)
-            self.apply_wallpaper(filename)
-            self.delete_last_wallpaper(filename)
-            logging.debug("Image {} applied.".format(filename))
-        except Exception as error:
-            logging.debug(error)
+check_res_argument()
+{
+    res="$1"
+    [ "$res" = "678" ] || [ "$res" = "1808" ] || [ "$res" = "5424" ] || [ "$res" = "10848" ] && echo 0 || echo 1
+}
 
-    def run(self):
-        self.apply_last_wallpaper()
-        starttime=time.time()
-        while True:
-            self.update_wallpaper()
-            time.sleep((60*10) - ((time.time() - starttime) % (60*10)))
+main()
+{
+    while getopts "hr:tl" args; do
+        case "${args}" in
+            r)
+                result=$(check_res_argument "${OPTARG}")
+                [ $result = 0 ] && download_image "${OPTARG}"
+                exit $((result))
+                ;;
+            t)
+                download_thumb
+                exit 0
+                ;;
+            l)
+                download_latest
+                exit 0
+                ;;
+            h | *)
+                usage
+                ;;
+        esac
+    done
+}
 
-if __name__ == "__main__":
-    logging.basicConfig(
-        filename=os.path.join('/tmp', 'goeswall.log'), 
-        level=logging.DEBUG, 
-        format='%(asctime)s %(message)s', datefmt='%m/%d/%Y %H:%M:%S'
-        )
-    parser = argparse.ArgumentParser(description='GOES Earth images as dynamic wallpaper.')
-    parser.add_argument(
-        '-r',
-        '--resolution',
-        type=str,
-        metavar='',
-        required=False,
-        help='Image Resolution. Should be: 339, 678, 1808, 5424 or 10848'
-        )
-    parser.add_argument(
-        '-p',
-        '--path',
-        type=str,
-        metavar='',
-        required=False,
-        help='path where you want to store the images'
-        )
-    
-    args = parser.parse_args()
-
-    if args.resolution in IMAGES_RESOLUTIONS and args.path:
-        goes_wallpaper = Wallpaper(
-            resolution=args.resolution,
-            folder=args.path
-            )
-    elif args.path:
-        goes_wallpaper = Wallpaper(
-            folder=args.path
-            )
-    elif args.resolution in IMAGES_RESOLUTIONS:
-        goes_wallpaper = Wallpaper(
-            resolution=args.resolution
-            )
-    else:
-        logging.debug("Starting with default values")
-        goes_wallpaper = Wallpaper()
-
-    goes_wallpaper.run()
+################################
+#   MAIN
+################################
+[ $# -eq 0 ] && usage || main $@

--- a/tgoeswall/tgoeswall
+++ b/tgoeswall/tgoeswall
@@ -18,30 +18,23 @@
 GOES_CDN="https://cdn.star.nesdis.noaa.gov/GOES16/ABI/FD/GEOCOLOR/"
 WGET_CMD="wget -N -q --show-progress"
 
+resolution=""
+path=""
+
 usage()
 {
     echo "usage: tgoeswall [-r <resolution>] [-t] [-l]"
     echo "options:"
-    echo "-r: download image by a given resolution(avaliable: 678, 1808, 5424, 10848);"
+    echo "-r: download image by a given resolution(available: 678, 1808, 5424, 10848);"
     echo "-t: download thumbnail image(the smallest image);"
     echo "-l: download latest image(the biggest image)."
-}
-
-
-download_latest()
-{
-    $WGET_CMD $GOES_CDN/latest.jpg
-}
-
-download_thumb()
-{
-    $WGET_CMD $GOES_CDN/thumbnail.jpg
+    exit 0
 }
 
 download_image()
 {
     res="$1"
-    $WGET_CMD $GOES_CDN/$res"x"$res".jpg"
+    $WGET_CMD "$GOES_CDN/$res.jpg"
 }
 
 check_res_argument()
@@ -56,25 +49,37 @@ main()
         case "${args}" in
             r)
                 result=$(check_res_argument "${OPTARG}")
-                [ $result = 0 ] && download_image "${OPTARG}"
-                exit $((result))
+                [ $result = 0 ] && resolution="${OPTARG}x${OPTARG}"
                 ;;
             t)
-                download_thumb
-                exit 0
+                resolution="thumbnail"
                 ;;
             l)
-                download_latest
-                exit 0
+                resolution="latest"
                 ;;
             h | *)
                 usage
                 ;;
         esac
     done
+
+    # Check if the resolution passed match with the resolution available in the goes cdn
+    [ -z "$resolution" ] && echo "resolution does not match the available ones." && usage
+
+    # Check if an argument has been passed without a getopt option, if it is passed, check if it is a valid path
+    shift $(expr $OPTIND - 1 )
+    while test $# -gt 0; do [ -d "$1" ] && path="$1"; shift; done
+
+    # if it is a valid path, add it to wget command
+    [ -z "$path" ] || WGET_CMD+=" -P $path"
+
+    # download the image
+    download_image $resolution
 }
 
 ################################
 #   MAIN
 ################################
+
 [ $# -eq 0 ] && usage || main $@
+

--- a/tgoeswall/tgoeswall.conf
+++ b/tgoeswall/tgoeswall.conf
@@ -1,4 +1,4 @@
 path:/tmp/tgoeswall/
 resolution: 1808
-feh_args: --bg-center
+feh_args: --bg-max
 

--- a/tgoeswall/tgoeswall.conf
+++ b/tgoeswall/tgoeswall.conf
@@ -1,0 +1,4 @@
+path:/tmp/tgoeswall/
+resolution: 1808
+feh_args: --bg-center
+

--- a/tgoeswall/tgoeswall.service
+++ b/tgoeswall/tgoeswall.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Service to make Geostationary Operational Environmental Satellite images, your wallpaper.
+Wants=network.target
+After=syslog.target network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/tgoeswallctrl
+

--- a/tgoeswall/tgoeswall.service
+++ b/tgoeswall/tgoeswall.service
@@ -4,5 +4,6 @@ Wants=network.target
 After=syslog.target network-online.target
 
 [Service]
-ExecStart=/usr/local/bin/tgoeswallctrl
+Environment=XAUTHORITY=~/.Xauthority
+ExecStart=/usr/bin/tgoeswallctrl
 

--- a/tgoeswall/tgoeswall.service
+++ b/tgoeswall/tgoeswall.service
@@ -5,5 +5,5 @@ After=syslog.target network-online.target
 
 [Service]
 Environment=XAUTHORITY=~/.Xauthority
-ExecStart=/usr/bin/tgoeswallctrl
+ExecStart=/usr/local/bin/tgoeswallctrl
 

--- a/tgoeswall/tgoeswall.timer
+++ b/tgoeswall/tgoeswall.timer
@@ -1,9 +1,9 @@
 [Unit]
 Description=Run tgoeswallctrl every 10 minutes
-Requires=tgoeswallctrl.service
+Requires=tgoeswall.service
 
 [Timer]
-Unit=tgoeswallctrl.service
+Unit=tgoeswall.service
 OnUnitInactiveSec=10m
 AccuracySec=1s
 

--- a/tgoeswall/tgoeswall.timer
+++ b/tgoeswall/tgoeswall.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run tgoeswallctrl every 10 minutes
+Requires=tgoeswallctrl.service
+
+[Timer]
+Unit=tgoeswallctrl.service
+OnUnitInactiveSec=10m
+AccuracySec=1s
+
+[Install]
+WantedBy=timers.target

--- a/tgoeswall/tgoeswallctrl
+++ b/tgoeswall/tgoeswallctrl
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+CFG_FILE_PATH="/etc/tgoeswall/tgoeswall.conf"
+
+image_path="/tmp/tgoeswall"
+resolution_image="1808"
+feh_args="--bg-center"
+
+load_config_file()
+{
+    echo "Loading config from file"
+    aux_image_path=$(tyaml $CFG_FILE_PATH -v path)
+    [ ! -z $aux_image_path ] && image_path=$aux_image_path
+    aux_resolution_image=$(tyaml $CFG_FILE_PATH -v resolution)
+    [ ! -z $aux_resolution_image ] && resolution_image=$aux_resolution_image
+    aux_feh_args=$(tyaml $CFG_FILE_PATH -v feh_args)
+    [ ! -z $aux_feh_args ] && feh_args=$aux_feh_args
+}
+
+[ -f $CFG_FILE_PATH ] && load_config_file
+

--- a/tgoeswall/tgoeswallctrl
+++ b/tgoeswall/tgoeswallctrl
@@ -24,13 +24,13 @@ load_config_file()
 download_goes_image()
 {
     echo "Downloading image with resolution $resolution_image..."
-    tgoeswall -r $resolution_image $aux_image_path
+    tgoeswall -r $resolution_image $image_path
 }
 
 apply_wallpaper()
 {
     echo "Applying image with resolution ($resolution_image) with feh args($feh_args)..."
-    feh $feh_args $image_path/$resolution_image*.jpg
+    DISPLAY=:0 XAUTHORITY=~/.Xauthority feh $feh_args $image_path/$resolution_image*.jpg
 }
 
 [ -f $CFG_FILE_PATH ] && load_config_file

--- a/tgoeswall/tgoeswallctrl
+++ b/tgoeswall/tgoeswallctrl
@@ -4,7 +4,7 @@ CFG_FILE_PATH="/etc/tgoeswall/tgoeswall.conf"
 
 image_path="/tmp/tgoeswall"
 resolution_image="1808"
-feh_args="--bg-center"
+feh_args="--bg-max"
 
 load_config_file()
 {
@@ -17,5 +17,20 @@ load_config_file()
     [ ! -z $aux_feh_args ] && feh_args=$aux_feh_args
 }
 
+download_goes_image()
+{
+    tgoeswall -r $resolution_image $aux_image_path
+}
+
+apply_wallpaper()
+{
+    feh $feh_args $image_path/$resolution_image*.jpg
+}
+
 [ -f $CFG_FILE_PATH ] && load_config_file
 
+[ ! -d $image_path ] && mkdir $image_path
+
+download_goes_image
+
+apply_wallpaper

--- a/tgoeswall/tgoeswallctrl
+++ b/tgoeswall/tgoeswallctrl
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CFG_FILE_PATH="/etc/tgoeswall/tgoeswall.conf"
+CFG_FILE_PATH="/etc/tinytools/tgoeswall.conf"
 
 image_path="/tmp/tgoeswall"
 resolution_image="1808"

--- a/tgoeswall/tgoeswallctrl
+++ b/tgoeswall/tgoeswallctrl
@@ -52,6 +52,38 @@ apply_wallpaper()
 
 [ ! -d $image_path ] && mkdir $image_path
 
-download_goes_image
+start_method()
+{
+    systemctl --user start tgoeswall
+}
 
-apply_wallpaper
+enable_method()
+{
+    systemctl --user enable -tgoeswall
+    start_method
+}
+
+usage()
+{
+    echo "usage: tgoeswallctrl"
+    echo "options:"
+    echo "-s|--start|start: start the service"
+    echo "-h|--help|help: show the usage"
+    exit 0
+}
+
+case "$1" in
+    -s | --start | start)
+        enable_method
+        start_method
+        ;;
+    -h | --help | help)
+        usage
+        ;;
+    *)
+        download_goes_image
+        apply_wallpaper
+        ;;
+
+esac
+

--- a/tgoeswall/tgoeswallctrl
+++ b/tgoeswall/tgoeswallctrl
@@ -8,22 +8,28 @@ feh_args="--bg-max"
 
 load_config_file()
 {
-    echo "Loading config from file"
+    echo "Loading config from file..."
     aux_image_path=$(tyaml $CFG_FILE_PATH -v path)
     [ ! -z $aux_image_path ] && image_path=$aux_image_path
     aux_resolution_image=$(tyaml $CFG_FILE_PATH -v resolution)
     [ ! -z $aux_resolution_image ] && resolution_image=$aux_resolution_image
     aux_feh_args=$(tyaml $CFG_FILE_PATH -v feh_args)
     [ ! -z $aux_feh_args ] && feh_args=$aux_feh_args
+    echo "Config loaded:"
+    echo "$image_path"
+    echo "$resolution_image"
+    echo "$feh_args"
 }
 
 download_goes_image()
 {
+    echo "Downloading image with resolution $resolution_image..."
     tgoeswall -r $resolution_image $aux_image_path
 }
 
 apply_wallpaper()
 {
+    echo "Applying image with resolution ($resolution_image) with feh args($feh_args)..."
     feh $feh_args $image_path/$resolution_image*.jpg
 }
 

--- a/tgoeswall/tgoeswallctrl
+++ b/tgoeswall/tgoeswallctrl
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+#This file is part of the TinyTools distribution (https://github.com/Calebe94/TinyTools).
+#Copyright (C)  TinyTools
+
+#This program is free software: you can redistribute it and/or modify
+#it under the terms of the GNU General Public License as published by
+#the Free Software Foundation, version 3 of the License.
+
+#This program is distributed in the hope that it will be useful,
+#but WITHOUT ANY WARRANTY; without even the implied warranty of
+#MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#GNU General Public License for more details.
+
+#You should have received a copy of the GNU General Public License
+#along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 CFG_FILE_PATH="/etc/tinytools/tgoeswall.conf"
 
 image_path="/tmp/tgoeswall"

--- a/tgoeswall/tgoeswallctrl
+++ b/tgoeswall/tgoeswallctrl
@@ -52,6 +52,11 @@ apply_wallpaper()
 
 [ ! -d $image_path ] && mkdir $image_path
 
+daemon_reload()
+{
+	systemctl --user daemon-reload
+}
+
 start_method()
 {
     systemctl --user start tgoeswall
@@ -59,7 +64,7 @@ start_method()
 
 enable_method()
 {
-    systemctl --user enable -tgoeswall
+    systemctl --user enable tgoeswall
     start_method
 }
 
@@ -74,6 +79,7 @@ usage()
 
 case "$1" in
     -s | --start | start)
+        daemon_reload
         enable_method
         start_method
         ;;

--- a/tgoeswall/tgoeswallctrl
+++ b/tgoeswall/tgoeswallctrl
@@ -59,12 +59,12 @@ daemon_reload()
 
 start_method()
 {
-    systemctl --user start tgoeswall
+    systemctl --user start tgoeswall.timer
 }
 
 enable_method()
 {
-    systemctl --user enable tgoeswall
+    systemctl --user enable tgoeswall.timer
     start_method
 }
 


### PR DESCRIPTION
Ported `tgoeswall` from python to bash, and changed some funcionalities.

Now the script `tgoeswall` is responsible to download the images, to apply the image you will have to call `feh` outside the script.

A service will be created to call `tgoeswall` every 10 minutes, to download the image and to apply as wallpaper.

