### PR TITLE
#131 ttodo makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,6 @@ ${CONFIG_FOLDER}:
 	@echo "Creating ${CONFIG_FOLDER} folder ..."
 	mkdir ${CONFIG_FOLDER}
 
-ttodo: ${CONFIG_FOLDER} ${BIN_FOLDER}
-	@echo "Installing ttodo..."
-	install -m 555 ttodo/ttodo ${BIN_FOLDER}
-	install -m 555 ttodo/dmenu_ttodo ${BIN_FOLDER}
-	@echo "done!"
-
 tyaml: ${CONFIG_FOLDER} ${BIN_FOLDER}
 	@echo "Installing tyaml..."
 	install -m 555 tyaml/tyaml ${BIN_FOLDER}
@@ -30,23 +24,23 @@ uninstall:
 	@echo "Removing tinytools..."
 	${MAKE} -C tsearch/ uninstall
 	${MAKE} -C tpomodoro/ uninstall
-	rm -f ${BIN_FOLDER}/ttodo
-	rm -f ${BIN_FOLDER}/dmenu_ttodo
 	${MAKE} -C tmenu/ uninstall
 	rm -f ${BIN_FOLDER}/tyaml
 	${MAKE} -C tnotes/ uninstall
 	rm -fr ${CONFIG_FOLDER}
 	${MAKE} -C tgoeswall/ uninstall
 	${MAKE} -C tprogbar/ uninstall
+	${MAKE} -C ttodo/ uninstall
 	@echo "done!"
 
-install: ttodo tyaml
+install: tyaml
 	${MAKE} -C tsearch/ install
 	${MAKE} -C tmenu/ install
 	${MAKE} -C tgoeswall/ install
 	${MAKE} -C tnotes/ install
 	${MAKE} -C tpomodoro/ install
 	${MAKE} -C tprogbar/ install
+	${MAKE} -C ttodo/ install
 	@echo "tinytools installed successfully!"
 
-.PHONY: install ttodo tyaml uninstall
+.PHONY: install tyaml uninstall

--- a/ttodo/Makefile
+++ b/ttodo/Makefile
@@ -1,0 +1,25 @@
+.POSIX:
+
+prefix = /usr/local
+
+all:
+	@echo "all target"
+
+install:
+	@echo "Installing ttodo..."
+	install -m 555 ttodo $(DESTDIR)/$(prefix)/bin/ttodo
+	install -m 555 dmenu_ttodo $(DESTDIR)/$(prefix)/bin/dmenu_ttodo
+	@echo "done!"
+
+clean:
+	@echo "Cleaning ttodo"
+
+distclean: clean
+
+uninstall:
+	@echo "Uninstall ttodo"
+	rm -f $(DESTDIR)/$(prefix)/bin/ttodo
+	rm -f $(DESTDIR)/$(prefix)/bin/dmenu_ttodo
+	@echo "done!"
+
+.PHONY: all install clean distclean uninstall


### PR DESCRIPTION
Updated `ttodo`'s Makefile.

To install it, just run:

`sudo make install`

And to uninstall:

`sudo make uninstall`